### PR TITLE
Fix OpenCV build dependencies

### DIFF
--- a/packages/cv/opencv/install_deps.sh
+++ b/packages/cv/opencv/install_deps.sh
@@ -27,6 +27,8 @@ apt-get install -y --no-install-recommends \
         libcanberra-gtk3-module \
         libeigen3-dev \
         libglew-dev \
+        libgl-dev \
+        libglu1-mesa-dev \
         libgstreamer-plugins-base1.0-dev \
         libgstreamer-plugins-good1.0-dev \
         libgstreamer1.0-dev \


### PR DESCRIPTION
## Summary
- add missing GL development libs in OpenCV install script

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68740e7424c8832f91b7f6d56c0e2cee